### PR TITLE
Fix missing newline in ironic-inspector.conf

### DIFF
--- a/etc/kayobe/kolla/config/ironic-inspector.conf
+++ b/etc/kayobe/kolla/config/ironic-inspector.conf
@@ -1,6 +1,7 @@
 [port_physnet]
 {% set mappings = [{'switches': groups['hs-eth-switches'], 'physnet': eod_hs_eth_physical_network}] %}
 switch_sys_name_mapping = {% for mapping in mappings %}{% for switch in mapping['switches'] %}{{ switch }}:{{ mapping['physnet'] }},{% endfor %}{% endfor %}
+
 ib_physnet = {{ eod_fdr_ib_physical_network }}
 
 [processing]


### PR DESCRIPTION
The extra new line is important

before:

[port_physnet]
switch_sys_name_mapping = ethsw-dr06-u20:physnet2,ib_physnet = physnet3

after:

[port_physnet]
switch_sys_name_mapping = ethsw-dr06-u20:physnet2,
ib_physnet = physnet3