### PR TITLE
Neutron high speed Ethernet & InfiniBand

### DIFF
--- a/etc/kayobe/compute.yml
+++ b/etc/kayobe/compute.yml
@@ -21,6 +21,7 @@ compute_bootstrap_user: centos
 # Add networks for compute nodes - devops.
 compute_extra_network_interfaces:
   - devops
+  - eod_hs_eth
 
 ###############################################################################
 # Compute node BIOS configuration.

--- a/etc/kayobe/controllers.yml
+++ b/etc/kayobe/controllers.yml
@@ -30,6 +30,7 @@ controller_extra_network_interfaces:
   - devops
   - wl_cleaning
   - wl_inspection
+  - eod_hs_eth
 
 # List of network interfaces to which network nodes are attached.
 #controller_network_host_network_interfaces:

--- a/etc/kayobe/inventory/group_vars/compute/network-interfaces
+++ b/etc/kayobe/inventory/group_vars/compute/network-interfaces
@@ -18,6 +18,15 @@ internal_interface: "{{ oc_provision_interface }}.{{ internal_vlan }}"
 # Storage network interface.
 storage_interface: "{{ oc_provision_interface }}.{{ storage_vlan }}"
 
+# Management network interface.
+# TODO: Uncomment this when using the admin network instead of oc_provision.
+#eod_mgmt_interface: breno1
+
+# Management network tagged bridge ports.
+# TODO: Uncomment this when using the admin network instead of oc_provision.
+#eod_mgmt_bridge_ports:
+#  - eno1
+
 # High speed Ethernet network interface.
 eod_hs_eth_interface: breth0
 

--- a/etc/kayobe/inventory/group_vars/compute/network-interfaces
+++ b/etc/kayobe/inventory/group_vars/compute/network-interfaces
@@ -18,6 +18,13 @@ internal_interface: "{{ oc_provision_interface }}.{{ internal_vlan }}"
 # Storage network interface.
 storage_interface: "{{ oc_provision_interface }}.{{ storage_vlan }}"
 
+# High speed Ethernet network interface.
+eod_hs_eth_interface: breth0
+
+# High speed Ethernet network tagged bridge ports.
+eod_hs_eth_bridge_ports:
+  - eth0
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/inventory/group_vars/controllers/network-interfaces
@@ -33,6 +33,13 @@ internal_interface: "{{ oc_provision_interface }}.{{ internal_vlan }}"
 # Storage network interface.
 storage_interface: "{{ oc_provision_interface }}.{{ storage_vlan }}"
 
+# High speed Ethernet network interface.
+eod_hs_eth_interface: breth0
+
+# High speed Ethernet network tagged bridge ports.
+eod_hs_eth_bridge_ports:
+  - eth0
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -252,6 +252,7 @@ kolla_enable_ceph: False
 #kolla_enable_neutron_agent_ha:
 #kolla_enable_neutron_bgp_dragent:
 #kolla_enable_neutron_provider_networks:
+kolla_enable_neutron_provider_networks: True
 #kolla_enable_nova_serialconsole_proxy:
 #kolla_enable_octavia:
 #kolla_enable_osprofiler:

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -36,6 +36,7 @@ internal_net_name: internal
 #external_net_names:
 external_net_names:
   - ilab
+  - eod_hs_eth
 
 # Name of the network used to expose the public OpenStack API endpoints.
 #public_net_name:

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -35,7 +35,8 @@ internal_net_name: internal
 # containing one item, external_net_name.
 #external_net_names:
 external_net_names:
-  - ilab
+  # FIXME: Replace with eod_mgmt when using the admin network for SSH access.
+  - oc_provision
   - eod_hs_eth
 
 # Name of the network used to expose the public OpenStack API endpoints.

--- a/etc/kayobe/neutron.yml
+++ b/etc/kayobe/neutron.yml
@@ -29,8 +29,8 @@ kolla_neutron_ml2_mechanism_drivers:
 kolla_neutron_ml2_network_vlan_ranges:
   - physical_network: "{{ eod_mgmt_physical_network }}"
     range: 1000:1999
-  #- physical_network: "{{ eod_hs_eth_physical_network }}"
-  #  range: changeme
+  - physical_network: "{{ eod_hs_eth_physical_network }}"
+    range: 1000:1999
 
 # List of Neutron ML2 extention drivers to use.
 #kolla_neutron_ml2_extension_drivers:

--- a/etc/kayobe/opensm.yml
+++ b/etc/kayobe/opensm.yml
@@ -4,7 +4,6 @@
 
 # Whether OpenSM is enabled.
 #opensm_enabled:
-opensm_enabled: True
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.


### PR DESCRIPTION
The 40G Ethernet network has been tested with VMs using iperf, giving us 14-15 Gbit/s over a provider VLAN (no SR-IOV or other performance optimisations).

The IB network has been tested with bare metal instances using ib_send_bw, and achieved around 48 Gbit/s.