### PR TITLE
Include Keystone configuration to support OpenID Connect

### DIFF
--- a/etc/kayobe/kolla/config/horizon/local_settings
+++ b/etc/kayobe/kolla/config/horizon/local_settings
@@ -207,7 +207,7 @@ AVAILABLE_REGIONS = [
 
 OPENSTACK_HOST = "{{ kolla_internal_fqdn }}"
 
-OPENSTACK_KEYSTONE_URL = "{{ keystone_public_url }}"
+OPENSTACK_KEYSTONE_URL = "{{ keystone_public_url }}/v3"
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 
 # Enables keystone web single-sign-on if set to True.

--- a/etc/kayobe/kolla/config/keystone/keystone.conf
+++ b/etc/kayobe/kolla/config/keystone/keystone.conf
@@ -1,0 +1,9 @@
+[auth]
+methods = password, token, oidc
+oidc = keystone.auth.plugins.mapped.Mapped
+
+[oidc]
+remote_id_attribute = HTTP_OIDC_ISS
+
+[federation]
+trusted_dashboard = http://{% raw %}{{ kolla_external_fqdn }}{% endraw %}/auth/websso/


### PR DESCRIPTION
A few additional options are required in Keystone's main configuration file in order to support authentication via the OpenID Connect protocol, which includes services such as EGI's Check-in AAI.