### PR TITLE
Fixes for heat scaling issues

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -119,6 +119,10 @@ kolla_build_blocks:
   #  # Install plugin for Gantt charts
   #  RUN grafana-cli plugins install natel-discrete-panel
   #  RUN grafana-cli plugins install vonage-status-panel
+  heat_base_footer: |
+    # Install from the stable/queens branch to pull in a fix for
+    # https://storyboard.openstack.org/#!/story/2003015.
+    RUN pip install -U --no-deps git+https://github.com/openstack/heat@stable/queens
   ironic_inspector_footer: |
     # Install our custom inspector plugins.
     RUN pip install stackhpc-inspector-plugins

--- a/etc/kayobe/kolla/config/heat.conf
+++ b/etc/kayobe/kolla/config/heat.conf
@@ -1,3 +1,8 @@
+[DEFAULT]
+# Increase the RPC response timeout - we sometimes see timeouts when processing
+# large stacks.
+rpc_response_timeout = 120
+
 [keystone_authtoken]
 # Check the roles of a service token against service_token_roles.
 service_token_roles_required = True


### PR DESCRIPTION
Pulls in a fix for https://storyboard.openstack.org/#!/story/2003015 where a
port cannot be deleted from a stack that has been deleted in neutron.

Also increases RPC messaging timeout to 120 seconds, as we were seeing timeouts
at the default of 60 seconds.