### PR TITLE
Declare admin_oc_net_name

### DIFF
--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -59,6 +59,9 @@ inspection_net_name: wl_inspection
 #cleaning_net_name:
 cleaning_net_name: wl_cleaning
 
+# Currently unused but needs to be declared
+admin_oc_net_name:
+
 ###############################################################################
 # Network definitions.
 


### PR DESCRIPTION
Although (currently?) unused, this variable needs to be declared
otherwise some tasks fail causing Kayobe reconfiguration runs to bomb
out.